### PR TITLE
Add quirk so bleatt/service/serial works with a 2 byte service UUID

### DIFF
--- a/util/uuid.go
+++ b/util/uuid.go
@@ -126,7 +126,8 @@ func (base UUID) CreateVariant(key uint8) UUID {
 }
 
 func (base UUID) CreateVariantAlt(key uint8) UUID {
-	if base.GetLength() != 16 {
+	// also allow 2 byte UUIDS as a quirk
+	if base.GetLength() != 16 && base.GetLength() != 2 {
 		panic("Variant creation is only possible for random UUID")
 	}
 


### PR DESCRIPTION
A real-world device was encountered that has a service with 2 byte UUID and that is compatible with bleatt/service/serial